### PR TITLE
Update to protolint 0.31.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM alpine:3.11.2
 
 RUN apk add curl
 
-ARG PROTOLINT_VERSION=0.23.1
+ARG PROTOLINT_VERSION=0.31.0
 RUN curl -LO https://github.com/yoheimuta/protolint/releases/download/v${PROTOLINT_VERSION}/protolint_${PROTOLINT_VERSION}_Linux_x86_64.tar.gz \
     && tar xf protolint_${PROTOLINT_VERSION}_Linux_x86_64.tar.gz \
     && chmod +x protolint \


### PR DESCRIPTION
This PR proposes to update the Docker container to use `protolint` v0.31.0 rather than 0.23.1. I'm not sure whether the maintainers would like to consider an alternate means of specifying the version that is to be run (e.g., using an environment variable or similar) -- but this seemed the simplest way to make the change.

Thanks for reviewing the change and putting together the action.

Thanks,
r.